### PR TITLE
adding go modules support for this repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
 #
   voting-orbs-tests:
     docker:
-      - image: circleci/golang:1.11.4
+      - image: circleci/golang:1.12.9
     steps:
       - checkout
       - run: cd voting/orbs && ./test.sh

--- a/asb/docker/Dockerfile
+++ b/asb/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.4
+FROM golang:1.12.9
 
 RUN apt-get update
 
@@ -14,7 +14,7 @@ ENV GAMMA_HOST="gamma"
 
 COPY asb/docker/bring-gamma.sh /tmp/bring-gamma.sh
 
-WORKDIR /go/src/github.com/orbs-network/orbs-ethereum-contracts/asb/test
+#WORKDIR /go/src/github.com/orbs-network/orbs-ethereum-contracts/asb/test
 
 COPY asb/docker/entrypoint.sh .
 COPY asb/test .
@@ -26,7 +26,6 @@ RUN rm -f orbs-gamma-config.json && \
     mv truffle-config.docker.js truffle-config.js
 
 RUN bash /tmp/bring-gamma.sh
-RUN go get ./... && \
-    yarn
+RUN yarn
 
 CMD ["/bin/bash", "entrypoint.sh"]

--- a/asb/docker/entrypoint.sh
+++ b/asb/docker/entrypoint.sh
@@ -4,4 +4,4 @@
 mkdir -p build/contracts
 cp ../build/ethereum/*.json ./build/contracts
 
-go test . -run TestFullFlowOnGanache -v -count 1
+go test . -run TestFullFlowOnGanache -v -count=1

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/orbs-network/orbs-ethereum-contracts
+
+go 1.12
+
+require (
+	github.com/orbs-network/go-junit-report v0.0.0-20190205202739-01ed406ba68b // indirect
+	github.com/orbs-network/orbs-contract-sdk v1.2.0
+	github.com/pkg/errors v0.8.1
+	github.com/stretchr/testify v1.4.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/orbs-network/go-junit-report v0.0.0-20190205202739-01ed406ba68b h1:AIwbJ7KYtbjCJ9GixspAKwJQLYHSgQU052L8v/YyFUg=
+github.com/orbs-network/go-junit-report v0.0.0-20190205202739-01ed406ba68b/go.mod h1:9v5wt4irDruG1pECl5fZ/zm2/rO56X2a/d9HBMqUluc=
+github.com/orbs-network/orbs-contract-sdk v1.2.0 h1:TX/oTR9+DrVHsYw6mqpEnQ2SVwCYbJoPbtWVAo1eNJA=
+github.com/orbs-network/orbs-contract-sdk v1.2.0/go.mod h1:N+caPmVwyn3p+kgPwfb43bo4qAcRDoiaq/gw/ag1mHo=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/subscription/docker/Dockerfile
+++ b/subscription/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.4
+FROM golang:1.12.9
 
 RUN apt-get update
 
@@ -36,7 +36,6 @@ RUN rm -f orbs-gamma-config.json && \
     mv truffle-config.docker.js truffle-config.js
 
 RUN bash /tmp/bring-gamma.sh
-RUN go get -t ./... && \
-    yarn install
+RUN yarn install
 
 CMD ["/bin/bash", "entrypoint.sh"]

--- a/voting/orbs/test.sh
+++ b/voting/orbs/test.sh
@@ -2,7 +2,7 @@
 mkdir -p _out
 mkdir -p _reports
 go get -u github.com/orbs-network/go-junit-report
-go get -d -t -v ./...
+#go get -d -t -v ./...
 go test ./... -v &> _out/test.out # so that we always go to the junit report step
 go-junit-report -set-exit-code < _out/test.out > _out/results.xml
 EXITCODE=$?


### PR DESCRIPTION
## Description

This PR deals with adding Go modules support into this project so that the Dockerfile(s) which we build during this project's CI runs will use Go 1.12.9 and of course use Go modules instead of using vendoring.

## Types of changes

This might be a breaking change but no service or downtime is anticipated for this project.

## Further comments

This is a part of our ongoing effort to integrate Go modules into all of our workflows.