### PR TITLE
Pos v2 readyforcomittee

### DIFF
--- a/pos-v2/test/driver.ts
+++ b/pos-v2/test/driver.ts
@@ -100,6 +100,10 @@ export class Participant {
     async registerAsValidator() {
         return await this.elections.registerValidator(this.ip, this.orbsAddress, {from: this.address});
     }
+
+    async notifyReadyForCommittee() {
+        return await this.elections.notifyReadyForCommittee({from: this.address});
+    }
 }
 
 export async function expectRejected(promise: Promise<any>, msg?: string) {

--- a/pos-v2/test/rewards.ts
+++ b/pos-v2/test/rewards.ts
@@ -32,11 +32,13 @@ contract('rewards-level-flows', async () => {
     const v1 = d.newParticipant();
     await v1.stake(initStakeLesser);
     await v1.registerAsValidator();
+    await v1.notifyReadyForCommittee();
 
     const initStakeLarger = new BN(21000);
     const v2 = d.newParticipant();
     await v2.stake(initStakeLarger);
     await v2.registerAsValidator();
+    await v2.notifyReadyForCommittee();
 
     const rate = 20000000;
     const subs = await d.newSubscriber('tier', rate);

--- a/pos-v2/typings/elections-contract.d.ts
+++ b/pos-v2/typings/elections-contract.d.ts
@@ -9,6 +9,7 @@ declare namespace Contracts {
         unstaked(stakeOwner: string, amount: number, params?: TransactionDetails): Promise<TransactionResponse>
         delegate(to: string, params?: TransactionDetails): Promise<TransactionResponse>
         getTopology(): Promise<TransactionResponse>
+        notifyReadyForCommittee(params?: TransactionDetails): Promise<TransactionResponse>
     }
 
     export interface DelegatedEvent {


### PR DESCRIPTION
Implements the "ready for committee" signal feature. A validator will send a transaction after it is synced while in the topology to indicated it's prepared to enter a committee.